### PR TITLE
fix: importing from lit-element is deprecated, using lit instead

### DIFF
--- a/frontend/src/example-template.ts
+++ b/frontend/src/example-template.ts
@@ -1,4 +1,4 @@
-import {html, LitElement} from "lit-element";
+import {html, LitElement} from "lit";
 
 
 class ExampleTemplate extends LitElement {


### PR DESCRIPTION
fixes  https://github.com/vaadin/flow-spring-examples/issues/139 
